### PR TITLE
NO MAXVALUE option for sequences

### DIFF
--- a/db_migrator--0.9.0.sql
+++ b/db_migrator--0.9.0.sql
@@ -940,9 +940,9 @@ BEGIN
          FROM sequences
    LOOP
       BEGIN
-      EXECUTE format('CREATE SEQUENCE %I.%I INCREMENT %s MINVALUE %s MAXVALUE %s START %s CACHE %s %sCYCLE',
-                     sch, seq, incr, minv, maxv, lastval + 1, cachesiz,
-                     CASE WHEN cycl THEN '' ELSE 'NO ' END);
+      EXECUTE format('CREATE SEQUENCE %I.%I INCREMENT %s MINVALUE %s %s START %s CACHE %s %sCYCLE',
+                     sch, seq, incr, minv, CASE WHEN maxv IS NULL THEN 'NO MAXVALUE' ELSE 'MAXVALUE ' || maxv END,
+                     lastval + 1, cachesiz, CASE WHEN cycl THEN '' ELSE 'NO ' END);
       EXCEPTION
          WHEN others THEN
             /* turn the error into a warning */
@@ -966,9 +966,9 @@ BEGIN
                   pgstage_schema,
                   sch,
                   seq,
-                  format('CREATE SEQUENCE %I.%I INCREMENT %s MINVALUE %s MAXVALUE %s START %s CACHE %s %sCYCLE',
-                         sch, seq, incr, minv, maxv, lastval + 1, cachesiz,
-                         CASE WHEN cycl THEN '' ELSE 'NO ' END),
+                  format('CREATE SEQUENCE %I.%I INCREMENT %s MINVALUE %s %s START %s CACHE %s %sCYCLE',
+                         sch, seq, incr, minv, CASE WHEN maxv IS NULL THEN 'NO MAXVALUE' ELSE 'MAXVALUE ' || maxv END,
+                         lastval + 1, cachesiz, CASE WHEN cycl THEN '' ELSE 'NO ' END),
                   errmsg || coalesce(': ' || detail, '')
                );
 


### PR DESCRIPTION
Hi !

This PR adds a condition in `db_migrate_mkforeign()` during sequences creation.

When `sequence.maxvalue` is null, the NO MAXVALUE option is provided to construct a valid SQL instruction. Required for mysql_migrator plugin as sequences are built from auto_increment table attribut. 

---

See issue [fljdin/mysql_migrator/issues/1](https://github.com/fljdin/mysql_migrator/issues/1)

```
NOTICE:  Creating sequences ...
WARNING:  Error creating sequence sakila.actor_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.address_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.category_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.city_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.country_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.customer_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.film_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.inventory_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.language_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.payment_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.rental_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.staff_seq
DETAIL:  syntax error at or near "START": 
WARNING:  Error creating sequence sakila.store_seq
DETAIL:  syntax error at or near "START": 
```

