### PR TITLE
Support declarative partitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,64 @@ are done with the migration.
 
   Modify this column if desired.
 
+### `partitions` ###
+
+- `schema` (type `name`): schema of the table with the partition
+
+- `table_name` (type `name`): name of the related table
+
+- `partition_name` (type `name`): name of the partition
+
+- `orig_name` (type `name`): name of the partition in the remote source
+
+- `type` (type `text`): one of the supported partitioning methods `LIST`,
+  `RANGE` or `HASH`
+
+- `expression` (type `text`): partitioning expression used to define a table's
+  partitioning
+
+- `position` (type `integer`): defines the order of the table partitions (must
+  start at 1)
+
+- `values` (type `text`): for a `RANGE` method, contains the upper bound value,
+  for a `LIST` method, contains a list of comma-separated values
+
+- `is_default` (type `boolean`, default `FALSE`); `TRUE` if it is the default
+  partition 
+
+- `migrate` (type `boolean`, default `TRUE`): `TRUE` if the constraint should
+  be migrated
+
+### `subpartitions` ###
+
+- `schema` (type `name`): schema of the table with the partition
+
+- `table_name` (type `name`): name of the related table
+
+- `partition_name` (type `name`): name of the parent partition
+
+- `subpartition_name` (type `name`): name of the subpartitions
+
+- `orig_name` (type `name`): name of the subpartition in the remote source
+
+- `type` (type `text`): one of the supported partitioning methods `LIST`,
+  `RANGE` or `HASH`
+
+- `expression` (type `text`): partitioning expression used to define a table's
+  composite partitioning
+
+- `position` (type `integer`): defines the order of the table subpartitions
+  (must start at 1)
+
+- `values` (type `text`): for a `RANGE` method, contains the upper bound value,
+  for a `LIST` method, contains a list of comma-separated values
+
+- `is_default` (type `boolean`, default `FALSE`); `TRUE` if it is the default
+  subpartition 
+
+- `migrate` (type `boolean`, default `TRUE`): `TRUE` if the constraint should
+  be migrated
+
 ### `views` ###
 
 - `schema` (type `name`): schema of the table with the view
@@ -678,6 +736,9 @@ Parameters:
 
 This function replaces a single foreign table created by `db_migrate_mkforeign`
 with an actual table.
+If any partition scheme exists in `partitions` or `subpartitions` tables, table
+will materialized as a partitioned table with partitions, while `migrate` are
+set to `TRUE`.
 The table data are migrated unless `with_data` is `FALSE`.
 
 You don't need this function if you use `db_migrate_tables`.  It is provided as
@@ -1073,6 +1134,46 @@ The columns of the view are defines in the `columns` table.
   rather than an expression
 
 - `column_name` is the indexed column name or expression
+
+### table of partitions ###
+
+    partitions (
+        schema         name    NOT NULL,
+        table_name     name    NOT NULL,
+        partition_name name    NOT NULL,
+        type           text    NOT NULL,
+        expression     text    NOT NULL,
+        position       integer NOT NULL,
+        values         text,
+        is_default     boolean NOT NULL
+    )
+
+- `type` is one of the supported partitioning methods `LIST`, `RANGE` or `HASH`
+
+- `expression` is used to define a table's partitioning
+
+- `position` defines the order of the table partitions (must start at 1)
+
+- `values` contains the upper bound value for a `RANGE` method or a list of
+  comma-separated values for a `LIST` method
+
+- `is_default` is `TRUE` if it is the default partition 
+
+### table of subpartitions ###
+
+    subpartitions (
+        schema            name    NOT NULL,
+        table_name        name    NOT NULL,
+        partition_name    name    NOT NULL,
+        subpartition_name name    NOT NULL,
+        type              text    NOT NULL,
+        expression        text    NOT NULL,
+        position          integer NOT NULL,
+        values            text,
+        is_default        boolean NOT NULL
+    )
+
+Same explanations as `partitions` above.
 
 ### table of triggers ###
 

--- a/README.md
+++ b/README.md
@@ -353,17 +353,11 @@ are done with the migration.
 - `expression` (type `text`): partitioning expression used to define a table's
   partitioning
 
-- `position` (type `integer`): defines the order of the table partitions (must
-  start at 1)
-
-- `values` (type `text`): for a `RANGE` method, contains the upper bound value,
-  for a `LIST` method, contains a list of comma-separated values
+- `values` (type `text[]`): partition bound specifications depending on
+  partition type
 
 - `is_default` (type `boolean`, default `FALSE`); `TRUE` if it is the default
-  partition 
-
-- `migrate` (type `boolean`, default `TRUE`): `TRUE` if the partition should
-  be migrated
+  partition
 
 ### `subpartitions` ###
 
@@ -383,17 +377,11 @@ are done with the migration.
 - `expression` (type `text`): partitioning expression used to define a table's
   composite partitioning
 
-- `position` (type `integer`): defines the order of the table subpartitions
-  (must start at 1)
-
-- `values` (type `text`): for a `RANGE` method, contains the upper bound value,
-  for a `LIST` method, contains a list of comma-separated values
+- `values` (type `text[]`): partition bound specifications depending on
+  partition type
 
 - `is_default` (type `boolean`, default `FALSE`); `TRUE` if it is the default
-  subpartition 
-
-- `migrate` (type `boolean`, default `TRUE`): `TRUE` if the partition should
-  be migrated
+  subpartition
 
 ### `views` ###
 
@@ -1143,21 +1131,26 @@ The columns of the view are defines in the `columns` table.
         partition_name name    NOT NULL,
         type           text    NOT NULL,
         expression     text    NOT NULL,
-        position       integer NOT NULL,
-        values         text,
-        is_default     boolean NOT NULL
+        is_default     boolean NOT NULL,
+        values         text[]
     )
 
 - `type` is one of the supported partitioning methods `LIST`, `RANGE` or `HASH`
 
 - `expression` is used to define a table's partitioning
 
-- `position` defines the order of the table partitions (must start at 1)
-
-- `values` contains the upper bound value for a `RANGE` method or a list of
-  comma-separated values for a `LIST` method
+- `values` are partition bound specifications depending on partition type
 
 - `is_default` is `TRUE` if it is the default partition 
+
+With `LIST` partitioning, `values` contains a list of properly quoted values, as
+it can store any data type, like integer, varchar or even expressions.
+
+With `RANGE` partitioning, `values` must be a two-value array to define preperly
+quoted boundaries, like `[lower, upper]`.
+
+With `HASH` partitioning, `values` must be a two-integer array, like `[modulus,
+remainder]`.
 
 ### table of subpartitions ###
 
@@ -1168,9 +1161,8 @@ The columns of the view are defines in the `columns` table.
         subpartition_name name    NOT NULL,
         type              text    NOT NULL,
         expression        text    NOT NULL,
-        position          integer NOT NULL,
-        values            text,
-        is_default        boolean NOT NULL
+        is_default        boolean NOT NULL,
+        values            text[]
     )
 
 Same explanations as `partitions` above.

--- a/README.md
+++ b/README.md
@@ -339,9 +339,9 @@ are done with the migration.
 
 ### `partitions` ###
 
-- `schema` (type `name`): schema of the table with the partition
+- `schema` (type `name`): schema of the partitioned table
 
-- `table_name` (type `name`): name of the related table
+- `table_name` (type `name`): name of the partitioned table
 
 - `partition_name` (type `name`): name of the partition
 
@@ -362,18 +362,18 @@ are done with the migration.
 - `is_default` (type `boolean`, default `FALSE`); `TRUE` if it is the default
   partition 
 
-- `migrate` (type `boolean`, default `TRUE`): `TRUE` if the constraint should
+- `migrate` (type `boolean`, default `TRUE`): `TRUE` if the partition should
   be migrated
 
 ### `subpartitions` ###
 
-- `schema` (type `name`): schema of the table with the partition
+- `schema` (type `name`): schema of the partitioned table
 
-- `table_name` (type `name`): name of the related table
+- `table_name` (type `name`): name of the partitioned table
 
 - `partition_name` (type `name`): name of the parent partition
 
-- `subpartition_name` (type `name`): name of the subpartitions
+- `subpartition_name` (type `name`): name of the subpartition
 
 - `orig_name` (type `name`): name of the subpartition in the remote source
 
@@ -392,7 +392,7 @@ are done with the migration.
 - `is_default` (type `boolean`, default `FALSE`); `TRUE` if it is the default
   subpartition 
 
-- `migrate` (type `boolean`, default `TRUE`): `TRUE` if the constraint should
+- `migrate` (type `boolean`, default `TRUE`): `TRUE` if the partition should
   be migrated
 
 ### `views` ###

--- a/db_migrator--0.9.0.sql
+++ b/db_migrator--0.9.0.sql
@@ -563,15 +563,20 @@ BEGIN
                    '          %1$s(table_name),\n'
                    '          %1$s(partition_name),\n'
                    '          partition_name,\n'
-                   '          type, expression, is_default, values\n'
-                   '   FROM %2$I.partitions\n'
+                   '          type, expression, is_default,\n'
+                   '          array_agg(%2$s(value) ORDER BY pos)\n'
+                   '   FROM %3$I.partitions\n'
+                   '   CROSS JOIN unnest(values) WITH ORDINALITY AS i (value, pos)\n'
                    '   WHERE $1 IS NULL OR schema = ANY($1)\n'
+                   '   GROUP BY schema, table_name, partition_name,\n'
+                   '            type, expression, is_default\n'
                    'ON CONFLICT ON CONSTRAINT partitions_pkey DO UPDATE SET\n'
                    '   type       = EXCLUDED.type,\n'
                    '   expression = EXCLUDED.expression,\n'
                    '   is_default = EXCLUDED.is_default,\n'
                    '   values     = EXCLUDED.values',
                    v_translate_identifier,
+                   v_translate_expression,
                    staging_schema) 
    USING only_schemas;
 
@@ -583,15 +588,20 @@ BEGIN
                    '          %1$s(partition_name),\n'
                    '          %1$s(subpartition_name),\n'
                    '          subpartition_name,\n'
-                   '          type, expression, is_default, values\n'
-                   '   FROM %2$I.subpartitions\n'
+                   '          type, expression, is_default,\n'
+                   '          array_agg(%2$s(value) ORDER BY pos)\n'
+                   '   FROM %3$I.subpartitions\n'
+                   '   CROSS JOIN unnest(values) WITH ORDINALITY AS i (value, pos)\n'
                    '   WHERE $1 IS NULL OR schema = ANY($1)\n'
+                   '   GROUP BY schema, table_name, partition_name, subpartition_name,\n'
+                   '            type, expression, is_default\n'
                    'ON CONFLICT ON CONSTRAINT subpartitions_pkey DO UPDATE SET\n'
                    '   type       = EXCLUDED.type,\n'
                    '   expression = EXCLUDED.expression,\n'
                    '   is_default = EXCLUDED.is_default,\n'
                    '   values     = EXCLUDED.values',
                    v_translate_identifier,
+                   v_translate_expression,
                    staging_schema) 
    USING only_schemas;
 


### PR DESCRIPTION
Enhances API with "partitions" and "subpartitions" new tables. Add steps in materialize_foreign_table() to support partitioned tables and partitions creation when needed. See README.md for further description.

Supports LIST (with default partition), RANGE, HASH and composite partitioning. The last position of a HASH partition is read before partition creation to obtain modulus value. Positions must start at 1.