### PR TITLE
Fix previous patch on partial indexes

### DIFF
--- a/db_migrator--1.0.0.sql
+++ b/db_migrator--1.0.0.sql
@@ -2126,12 +2126,7 @@ BEGIN
          stmt_wher_expr := '';
 
          IF wher <> '' THEN
-            /* translate where expression */
-            EXECUTE format(
-                        'SELECT %s(%L)',
-                        v_translate_expression,
-                        wher
-                  ) INTO stmt_wher_expr;
+            stmt_wher_expr := wher;
          END IF;
       END IF;
 


### PR DESCRIPTION
Hi

Duplicate use of v_translate_expression has been removed.

> Also, a new feature, particularly one that introduces an incompatibility, should bump the extension version.
> _Originally posted by @laurenz in https://github.com/cybertec-postgresql/db_migrator/issues/21#issuecomment-1634051758_

What version do you want? 1.1.0? 1.0.1?