### PR TITLE
Forbid extension's relocatability

### DIFF
--- a/db_migrator.control
+++ b/db_migrator.control
@@ -1,4 +1,4 @@
 comment = 'Tools to migrate other databases to PostgreSQL'
 default_version = '1.1.0'
 superuser = false
-relocatable = true
+relocatable = false


### PR DESCRIPTION
As future features (like #26) may introduce much more low-level functions, forbidding relocatability will prevent unnecessary lookups in pg_extension table.

Closes #31 